### PR TITLE
Remove `num` from the build

### DIFF
--- a/aeron-rs/Cargo.toml
+++ b/aeron-rs/Cargo.toml
@@ -14,7 +14,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 aeron_driver-sys = { path = "../aeron_driver-sys" }
 memmap = "0.7"
-num = "0.2"
 
 [dev-dependencies]
 clap = "2.33"

--- a/aeron-rs/src/client/cnc_descriptor.rs
+++ b/aeron-rs/src/client/cnc_descriptor.rs
@@ -67,7 +67,7 @@ pub struct MetaDataDefinition {
 /// Length of the metadata block in a CnC file. Note that it's not equivalent
 /// to the actual struct length.
 pub const META_DATA_LENGTH: usize =
-    bit::align_usize(size_of::<MetaDataDefinition>(), bit::CACHE_LINE_LENGTH * 2);
+    bit::align(size_of::<MetaDataDefinition>(), bit::CACHE_LINE_LENGTH * 2);
 
 /// Version code for the Aeron CnC file format
 pub const CNC_VERSION: i32 = crate::sematic_version_compose(0, 0, 16);

--- a/aeron-rs/src/client/concurrent/ring_buffer.rs
+++ b/aeron-rs/src/client/concurrent/ring_buffer.rs
@@ -147,8 +147,8 @@ impl<'a> ManyToOneRingBuffer<'a> {
         self.check_msg_length(length)?;
 
         let record_len = length + record_descriptor::HEADER_LENGTH;
-        let required = bit::align(record_len, record_descriptor::ALIGNMENT);
-        let record_index = self.claim_capacity(required)?;
+        let required = bit::align(record_len as usize, record_descriptor::ALIGNMENT as usize);
+        let record_index = self.claim_capacity(required as IndexT)?;
 
         // UNWRAP: `claim_capacity` performed bounds checking
         self.buffer

--- a/aeron-rs/src/util.rs
+++ b/aeron-rs/src/util.rs
@@ -24,7 +24,6 @@ pub type Result<T> = ::std::result::Result<T, AeronError>;
 /// Bit-level utility functions
 pub mod bit {
     use crate::util::IndexT;
-    use num::PrimInt;
 
     /// Length of the data blocks used by the CPU cache sub-system in bytes
     pub const CACHE_LINE_LENGTH: usize = 64;
@@ -40,7 +39,7 @@ pub mod bit {
         idx > 0 && (idx as u32).is_power_of_two()
     }
 
-    /// Align a specific value to the next largest alignment size.
+    /// Align a `usize` value to the next highest multiple.
     ///
     /// ```rust
     /// # use aeron_rs::util::bit::align;
@@ -50,15 +49,7 @@ pub mod bit {
     /// assert_eq!(align(52, 12), 52);
     /// assert_eq!(align(52, 16), 64);
     /// ```
-    pub fn align<T>(val: T, alignment: T) -> T
-    where
-        T: PrimInt,
-    {
-        (val + (alignment - T::one())) & !(alignment - T::one())
-    }
-
-    /// Align a `usize` value. See `align` for similar functionality on general types.
-    pub const fn align_usize(val: usize, alignment: usize) -> usize {
+    pub const fn align(val: usize, alignment: usize) -> usize {
         (val + (alignment - 1)) & !(alignment - 1)
     }
 }


### PR DESCRIPTION
Don't really need it at the moment, especially given that it doesn't function in a `const` context.
bors r+